### PR TITLE
Receive Slot Index for Using Items from Inventory

### DIFF
--- a/Assets/ItemDB/Not So Lucky Sword.prefab
+++ b/Assets/ItemDB/Not So Lucky Sword.prefab
@@ -57,6 +57,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 320ef2fe090406d4a9fe8199c477964d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _entityPrefabId: 4
+  _entityName: 
+  interactRadius: 3
+  gravity: -9.18
+  moveSpeed: 5
   item: {fileID: 11400000, guid: bfbc6cc0bec257140b27867c269c291d, type: 2}
 --- !u!1 &284073985645531311
 GameObject:

--- a/Assets/Scenes/ServerView.unity
+++ b/Assets/Scenes/ServerView.unity
@@ -168,6 +168,7 @@ MonoBehaviour:
   - {fileID: 8611467844914570594, guid: 8a3256f6f3a12a848a3443f4f31c64dc, type: 3}
   - {fileID: 8611467844914570594, guid: b18ee323596aff74bbcbce59a159fa54, type: 3}
   - {fileID: 284073984168042100, guid: c1ca30307112da348ac4b844f1bfcb58, type: 3}
+  - {fileID: 284073984168042100, guid: 0db320093ea3d5b448864bc2ed54428b, type: 3}
   playerPrefab: {fileID: 8611467844914570594, guid: 24a623eb0c8f3d8429cb79e502e24054,
     type: 3}
   enemyPrefab: {fileID: 8611467844914570594, guid: b18ee323596aff74bbcbce59a159fa54,

--- a/Assets/Scripts/GameServer.cs
+++ b/Assets/Scripts/GameServer.cs
@@ -138,8 +138,7 @@ public class GameServer
                 { (int)ClientPackets.clearFocus, ServerHandle.ClearFocus },
                 { (int)ClientPackets.killEnemy, ServerHandle.KillEnemy},
                 { (int)ClientPackets.requestInteract, ServerHandle.RequestInteract},
-                { (int)ClientPackets.requestUseItem, ServerHandle.OnUseItemRequested},
-                { (int)ClientPackets.requestEquipItem, ServerHandle.OnEquipItemRequested}
+                { (int)ClientPackets.requestUseItemSlot, ServerHandle.OnUseItemSlotRequested}
         };
         Debug.Log("Initialized packets.");
     }

--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -3,10 +3,12 @@
 [CreateAssetMenu(fileName = "New Item", menuName = "Inventory/Item")]
 public class Item : ScriptableObject
 {
-    public int id;
-    new public string name = "New Item";
-    public Sprite icon = null;
-    public bool isDefaultItem = false;
+    public int Id => id;
+    [SerializeField] private int id;
+
+    [SerializeField] new private string name = "New Item";
+    [SerializeField] private Sprite icon = null;
+    [SerializeField] private bool isDefaultItem = false;
 
     public virtual void Use(int _fromCID)
     {

--- a/Assets/Scripts/ItemDrop.cs
+++ b/Assets/Scripts/ItemDrop.cs
@@ -26,7 +26,7 @@ public class ItemDrop : Entity
             {
                 Debug.Log("Removed item from world");
                 Destroy(gameObject);
-                ServerSend.ItemLooted(_fromCID, NetworkId, item.id);
+                ServerSend.ItemLooted(_fromCID, NetworkId, item.Id);
             }
 
             return true;

--- a/Assets/Scripts/Packet.cs
+++ b/Assets/Scripts/Packet.cs
@@ -46,8 +46,7 @@ public enum ClientPackets
     interactableTooFar,
     requestFocus,
     interactionConfirmed,
-    requestUseItem,
-    requestEquipItem
+    requestUseItemSlot
 }
 public class Packet : IDisposable
     {

--- a/Assets/Scripts/RegularEquipment.cs
+++ b/Assets/Scripts/RegularEquipment.cs
@@ -14,7 +14,7 @@ public class RegularEquipment : Item
         base.Use(_fromCID);
         if (NetworkManager.instance.Server.Clients[_fromCID].player.equipmentManager != null)
         {
-            NetworkManager.instance.Server.Clients[_fromCID].player.equipmentManager.Equip(this, _fromCID, id);
+            NetworkManager.instance.Server.Clients[_fromCID].player.equipmentManager.Equip(this, _fromCID, Id);
         }
     }
 }

--- a/Assets/Scripts/ServerHandle.cs
+++ b/Assets/Scripts/ServerHandle.cs
@@ -103,52 +103,18 @@ public class ServerHandle
         }
     }
 
-    public static void OnUseItemRequested(int _fromClient, Packet _packet)
+    public static void OnUseItemSlotRequested(int _fromClient, Packet _packet)
     {
-        int _fromCID = _packet.ReadInt();
-        int _itemID = _packet.ReadInt();
-        string _itemName = _packet.ReadString();
-        Inventory _playerInventory = NetworkManager.instance.Server.Clients[_fromCID].player.GetComponent<Inventory>();
+        int fromCID = _packet.ReadInt();
+        int slotIndex = _packet.ReadInt();
+        Inventory playerInventory = NetworkManager.instance.Server.Clients[fromCID].player.GetComponent<Inventory>();
 
-        for (int i = 0; i < _playerInventory.items.Count; i++)
+        if (slotIndex < 0 || slotIndex >= playerInventory.bagSpace)
         {
-            if(_playerInventory.items[i].id == _itemID)
-            {
-                _playerInventory.items[i].Use(_fromCID);
-                //We don't want to spam use items if we have multiple,
-                //so just return out of the method after first use
-                return;
-            }
-            else
-            {
-                Debug.Log("That item doesn't exist in the players inventory...");
-            }
-            
+            Debug.Log($"Invalid slot index {slotIndex} received from {fromCID}");
         }
-    }
 
-    public static void OnEquipItemRequested(int _fromClient, Packet _packet)
-    {
-        int _fromCID = _packet.ReadInt();
-        int _itemID = _packet.ReadInt();
-        Inventory _playerInventory = NetworkManager.instance.Server.Clients[_fromCID].player.GetComponent<Inventory>();
-
-        for (int i = 0; i < _playerInventory.items.Count; i++)
-        {
-            if (_playerInventory.items[i].id == _itemID)
-            {
-                Debug.Log($"{NetworkManager.instance.Server.Clients[_fromCID].player.username} equipped item {_playerInventory.items[i].name}");
-                
-                //We don't want to spam use items if we have multiple,
-                //so just return out of the method after first use
-                return;
-            }
-            else
-            {
-                Debug.Log("That item doesn't exist in the players inventory...");
-            }
-
-        }
+        playerInventory.items[slotIndex].Use(fromCID);
     }
 
     public static void KillEnemy(int _fromClient, Packet _packet)


### PR DESCRIPTION
Instead of receiving the item id that is used when an item is clicked in the inventory, we receive the inventory slot index instead. This way, we don't have to loop through all items in the inventory and only need to handle what slot the item is in. The `Item.Use()` function can take it from there.